### PR TITLE
added missing API_URL variable for 0.9 run.sh

### DIFF
--- a/0.9/run.sh
+++ b/0.9/run.sh
@@ -56,6 +56,7 @@ if [ -n "${UDP_PORT}" ]; then
 fi
 
 # Pre create database on the initiation of the container
+API_URL="http://localhost:8086"
 if [ -n "${PRE_CREATE_DB}" ]; then
     echo "=> About to create the following database: ${PRE_CREATE_DB}"
     if [ -f "/data/.pre_db_created" ]; then


### PR DESCRIPTION
This fixes the initial creation problem with the 0.9 docker image

This might also fix the problem reported in issue #39 