### PR TITLE
Persistent Centralised InfluxDB Data & README.md additions

### DIFF
--- a/0.9/config.toml
+++ b/0.9/config.toml
@@ -3,7 +3,7 @@ port = 8086
 reporting-disabled = false
 
 [meta]
-  dir = "/var/opt/influxdb/meta"
+  dir = "/data/meta"
 
 [initialization]
   join-urls = ""
@@ -49,7 +49,7 @@ reporting-disabled = false
   write-tracing = false
   raft-tracing = false
   level  = "info"
-  file   = "/opt/influxdb/shared/log.txt"
+  file   = "/data/log/influxdb.log"
 
 [monitoring]
   enabled = false
@@ -66,4 +66,4 @@ reporting-disabled = false
 
 [hinted-handoff]
   enabled = true
-  dir = "/var/opt/influxdb/hh"
+  dir = "/data/hh"

--- a/README.md
+++ b/README.md
@@ -25,29 +25,54 @@ Tags
     tutum/influxdb:0.8.8  -> influxdb 0.8.8
 
 Running your InfluxDB image
---------------------------
+---------------------------
 
-Start your image binding the external ports `8083` and `8086` in all interfaces to your container. Ports `8090` and `8099` are only used for clustering and should not be exposed to the internet.
+Start your image binding the external ports `8083` and `8086` in all interfaces to your container. Ports `8090` and `8099` are only used for clustering and should not be exposed to the internet:
 
     docker run -d -p 8083:8083 -p 8086:8086 tutum/influxdb
+
+`Docker` containers are easy to delete. If you delete your container instance and your cluster goes offline, you'll lose the InfluxDB store and configuration. If you are serious about keeping InfluxDB data persistently, then consider adding a volume mapping to the containers `/data` folder:
+
+  docker run -d --volume=/var/influxdb:/data -p 8083:8083 -p 8086:8086 tutum/influxdb
 
 **Note**: `influxdb:0.9` is **NOT** backwards compatible with `0.8.x`. If you need version `0.8.x`, please run:
 
 	docker run -d -p 8083:8083 -p 8086:8086 tutum/influxdb:0.8.8
 
-
 Configuring your InfluxDB
 -------------------------
 Open your browse to access `localhost:8083` to configure InfluxDB. Fill the port which maps to `8086`. The default credential is `root:root`. Please change it as soon as possible.
 
-Alternatively, you can use RESTful API to talk to InfluxDB on port `8086`
+Alternatively, you can use RESTful API to talk to InfluxDB on port `8086`. For example, if you have problems with the initial database creation for version `0.9.x`, you can use the new `influx` cli tool to configure the database. While the container is running, you can enter the container interactively with the `influx` tool:
 
+  ```
+  docker exec -ti influxdb-container-name /opt/influxdb/influx
+  Connected to http://localhost:8086 version 0.9.1
+  InfluxDB shell 0.9.1
+  >
+  ```
 
 Initially create Database
 -------------------------
 Use `-e PRE_CREATE_DB="db1;db2;db3"` to create database named "db1", "db2", and "db3" on the first time the container starts automatically. Each database name is separated by `;`. For example:
 
 ```docker run -d -p 8083:8083 -p 8084:8084 -e PRE_CREATE_DB="db1;db2;db3" tutum/influxdb:latest```
+
+Alternatively, create a database and user with the InfluxDB shell:
+
+```
+  > CREATE DATABASE db1
+  > SHOW DATABASES
+  name: databases
+  ---------------
+  name
+  db1
+  > USE db1
+  > CREATE USER root WITH PASSWORD 'somepassword' WITH ALL PRIVILEGES
+  > SHOW USERS
+  user  admin
+  root  true
+```
 
 SSL support (Available only in influxdb:0.8.8)
 ---------------------------------------------
@@ -88,3 +113,4 @@ docker run --link masterinflux:master -p 8083 -p 8086 --expose 8090 --expose 809
   -e SEEDS="master:8090" -e FORCE_HOSTNAME="auto" \
   -d  tutum/influxdb
 ```
+

--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ Start your image binding the external ports `8083` and `8086` in all interfaces 
 
 `Docker` containers are easy to delete. If you delete your container instance and your cluster goes offline, you'll lose the InfluxDB store and configuration. If you are serious about keeping InfluxDB data persistently, then consider adding a volume mapping to the containers `/data` folder:
 
-  docker run -d --volume=/var/influxdb:/data -p 8083:8083 -p 8086:8086 tutum/influxdb
+    docker run -d --volume=/var/influxdb:/data -p 8083:8083 -p 8086:8086 tutum/influxdb
 
 **Note**: `influxdb:0.9` is **NOT** backwards compatible with `0.8.x`. If you need version `0.8.x`, please run:
 
-	docker run -d -p 8083:8083 -p 8086:8086 tutum/influxdb:0.8.8
+    docker run -d -p 8083:8083 -p 8086:8086 tutum/influxdb:0.8.8
 
 Configuring your InfluxDB
 -------------------------
 Open your browse to access `localhost:8083` to configure InfluxDB. Fill the port which maps to `8086`. The default credential is `root:root`. Please change it as soon as possible.
 
-Alternatively, you can use RESTful API to talk to InfluxDB on port `8086`. For example, if you have problems with the initial database creation for version `0.9.x`, you can use the new `influx` cli tool to configure the database. While the container is running, you can enter the container interactively with the `influx` tool:
+Alternatively, you can use RESTful API to talk to InfluxDB on port `8086`. For example, if you have problems with the initial database creation for version `0.9.x`, you can use the new `influx` cli tool to configure the database. While the container is running, you launch the tool with the following command:
 
   ```
   docker exec -ti influxdb-container-name /opt/influxdb/influx
@@ -113,4 +113,3 @@ docker run --link masterinflux:master -p 8083 -p 8086 --expose 8090 --expose 809
   -e SEEDS="master:8090" -e FORCE_HOSTNAME="auto" \
   -d  tutum/influxdb
 ```
-

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Alternatively, create a database and user with the InfluxDB 0.9 shell:
   user  admin
   root  true
 ```
-For additional Administration methods with the InfluxDB 0.9 shell, check out the ['Administration'](https://influxdb.com/docs/v0.9/administration/administration.html) guide on the InfluxDB website.
+For additional Administration methods with the InfluxDB 0.9 shell, check out the [`Administration`](https://influxdb.com/docs/v0.9/administration/administration.html) guide on the InfluxDB website.
 
 SSL support (Available only in influxdb:0.8.8)
 ---------------------------------------------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Start your image binding the external ports `8083` and `8086` in all interfaces 
 
 Configuring your InfluxDB
 -------------------------
-Open your browse to access `localhost:8083` to configure InfluxDB. Fill the port which maps to `8086`. The default credential is `root:root`. Please change it as soon as possible.
+Open your browser to access `localhost:8083` to configure InfluxDB. Fill the port which maps to `8086`. The default credential is `root:root`. Please change it as soon as possible.
 
 Alternatively, you can use RESTful API to talk to InfluxDB on port `8086`. For example, if you have problems with the initial database creation for version `0.9.x`, you can use the new `influx` cli tool to configure the database. While the container is running, you launch the tool with the following command:
 
@@ -58,7 +58,7 @@ Use `-e PRE_CREATE_DB="db1;db2;db3"` to create database named "db1", "db2", and 
 
 ```docker run -d -p 8083:8083 -p 8084:8084 -e PRE_CREATE_DB="db1;db2;db3" tutum/influxdb:latest```
 
-Alternatively, create a database and user with the InfluxDB shell:
+Alternatively, create a database and user with the InfluxDB 0.9 shell:
 
 ```
   > CREATE DATABASE db1
@@ -73,14 +73,15 @@ Alternatively, create a database and user with the InfluxDB shell:
   user  admin
   root  true
 ```
+For additional Administration methods with the InfluxDB 0.9 shell, check out the ['Administration'](https://influxdb.com/docs/v0.9/administration/administration.html) guide on the InfluxDB website.
 
 SSL support (Available only in influxdb:0.8.8)
 ---------------------------------------------
 By default, Influx DB uses port 8086 for HTTP API. If you want to use SSL API, you can set `SSL_SUPPORT` to `true`  as an environment variable. In that case, you can use HTTP API on port 8086 and HTTPS API on port 8084. Please do not publish port 8086 if you want to only allow HTTPS connection.
 
-If you provide `SSL_CERT`, system will use user provided ssl certificate. Otherwise system will create a self-signed certificated, which usually has an unauthorized cerificated problem, not recommend.
+If you provide `SSL_CERT`, system will use user provided SSL certificate. Otherwise the system will create a self-signed certificate, which usually has an unauthorized certificate error, not recommend.
 
-The cert file should be an combination of Private Key and Public Certificate. In order to pass it as an environment variable, you need specifically convert `newline` to `\n`(two characters). In order to do this, you can simply run the command `awk 1 ORS='\\n' <your_cert.pem>`. For example:
+The cert file should be a combination of Private Key and Public Certificate. In order to pass it as an environment variable, you need specifically convert `newline` to `\n`(two characters). In order to do this, you can simply run the command `awk 1 ORS='\\n' <your_cert.pem>`. For example:
 
 ```docker run -d -p 8083:8083 -p 8084:8084 -e SSL_SUPPORT="True" -e SSL_CERT="`awk 1 ORS='\\n' ~/cert.pem`" tutum/influxdb:latest```
 
@@ -96,18 +97,18 @@ Use :
 
 * `-e SEEDS="host1:8090, host2:8090"` to pass seeds nodes to your container.
 * `-e REPLI_FACTOR=x` where x is the replicator factor of shards through the cluster (defaults to 1)
-* `-e FORCE_HOSTNAME="auto"` to force the hostname in the config file to be set to the container IPv4 eth0 address (usefull to test clustering on a single docker host)
+* `-e FORCE_HOSTNAME="auto"` to force the hostname in the config file to be set to the container IPv4 eth0 address (useful to test clustering on a single docker host)
 * `-e FORCE_HOSTNAME="<whatever>" ` to force the hostname in the config file to be set to 'whatever'
 
-Example on a single docker host :
+Example on a single docker host:
 
-* launch first container :
+* Launch first container:
 ```
 docker run -p 8083:8083 -p 8086:8086 --expose 8090 --expose 8099 \
   -e FORCE_HOSTNAME="auto" -e REPLI_FACTOR=2 \
   -d --name masterinflux tutum/influxdb
 ```
-* then launch one or more "slaves":
+* Then launch one or more "slaves":
 ```
 docker run --link masterinflux:master -p 8083 -p 8086 --expose 8090 --expose 8099 \
   -e SEEDS="master:8090" -e FORCE_HOSTNAME="auto" \


### PR DESCRIPTION
When running 0.9 version of InfluxDB, I experienced issues with the database metadata with the new config.toml file. After stopping the container and removing it, even though I had mapped the `/data` folder through to the container, the new metadata location was not directed there and the database configuration was lost. I updated the new config file to use the `/data` folder and directed other useful items in the config.toml file that are useful to retain.

When I remove and recreated the container, all the configuration and influx data is retained when stored in the one folder that is exposed using the --volume switch.

I also updated the README.md to provide information on using the influx cli tool to configure InfluxDB 0.9 and add a not regarding retaining data in case the container is deleted and your whole cluster is offline.