### PR TITLE
Removed empty lines in config section graphite

### DIFF
--- a/0.9/config.toml
+++ b/0.9/config.toml
@@ -126,11 +126,9 @@ reporting-disabled = false
   consistency-level = "one"
   separator = "."
   database = "graphitedb"
-
   # These next lines control how batching works. You should have this enabled
   # otherwise you could get dropped metrics or poor performance. Batching
   # will buffer points in memory if you have many coming in.
-
   # batch-size = 1000 # will flush if this many points get buffered
   # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
   batch-size = 1000
@@ -138,13 +136,11 @@ reporting-disabled = false
   templates = [
      # filter + template
      #"*.app env.service.resource.measurement",
-
      # filter + template + extra tag
      #"stats.* .host.measurement* region=us-west,agent=sensu",
-
      # default template. Ignore the first graphite component "servers"
      "instance.profile.measurement*"
- ]
+  ]
 
 ###
 ### [collectd]


### PR DESCRIPTION
Replacement of variable GRAPHITE_TEMPLATE with sed command doesn't work if there are empty lines within the config section graphite