### PR TITLE
Add hint 0.9-specific init feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Alternatively, create a database and user with the InfluxDB 0.9 shell:
 For additional Administration methods with the InfluxDB 0.9 shell, check out the [`Administration`](https://influxdb.com/docs/v0.9/administration/administration.html) guide on the InfluxDB website.
 
 
-Initially execute influxql script (Available in influxdb:0.9)
+Initially execute influxql script (Available only in influxdb:0.9)
 ------------------------------------------------------------
 Use `-v /tmp/init_script.influxql:init_script.influxql:ro` if you want that script to been executed on the first time the container starts automatically. Each influxql command on separated line. For example:
 


### PR DESCRIPTION
Tripped over that one pretty harsh, as `init_script.influxql` is only available in the 0.9 tag. Would've helped to clarify that.